### PR TITLE
Add conditional block to retry operator to determine whether retry is possible.

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,20 @@ myAsyncFunc(param).retry(3).then { value in
 }
 ```
 
+Conditional retry allows you to control retryable if it ends with a rejection.
+
+```swift
+// If myAsyncFunc() fails the operator execute the condition block to check retryable.
+// If return false in condition block, promise state rejected with last catched error.
+myAsyncFunc(param).retry(3) { (remainAttempts, error) -> Bool in
+  return error.isRetryable
+}.then { value in
+	print("Value \(value) got at attempt #\(currentAttempt)")
+}.catch { err in
+	print("Failed to get a value after \(currentAttempt) attempts with error: \(err)")
+}
+```
+
 <a name="installation" />
 
 ## Installation


### PR DESCRIPTION
Hi dev.

I want to add feature that `retry` operator with conditional block to determine whether retry is possible even if not reached maximum retry count.
I think condition block will check current time date, remainAttempts, error type, user interacted cancel or other application state.

Best.