### PR TITLE
Fix: The `any` operator sometimes does not work.

### DIFF
--- a/Sources/Hydra/Promise+Any.swift
+++ b/Sources/Hydra/Promise+Any.swift
@@ -58,6 +58,7 @@ public func any<L>(in context: Context? = nil, _ promises: [Promise<L>]) -> Prom
 		for currentPromise in promises {
 			// first promises which resolve is returned
 			currentPromise.add(in: context, onResolve: resolve, onReject: reject)
+			currentPromise.runBody()
 		}
 	}
 	return anyPromise

--- a/Tests/HydraTests/HydraTests.swift
+++ b/Tests/HydraTests/HydraTests.swift
@@ -357,6 +357,32 @@ class HydraTestThen: XCTestCase {
 		waitForExpectations(timeout: expTimeout, handler: nil)
 	}
 	
+	func test_anyWithAllBodyPromise() {
+		let exp = expectation(description: "test_anyWithAllBodyPromise")
+		let promise1 = intPromiseDelay(100, delay: 0.1)
+		let promise2 = intPromise(5)
+		any(promise1, promise2).then { result in
+			XCTAssertEqual(result, promise1.result!)
+			exp.fulfill()
+			}.catch { _ in
+				XCTFail()
+		}
+		waitForExpectations(timeout: expTimeout, handler: nil)
+	}
+	
+	func test_anyWithArrayAllBodyPromise() {
+		let exp = expectation(description: "test_anyWithArrayAllBodyPromise")
+		let promise1 = intPromiseDelay(100, delay: 0.1)
+		let promise2 = intPromise(5)
+		any([promise1, promise2]).then { result in
+			XCTAssertEqual(result, promise1.result!)
+			exp.fulfill()
+			}.catch { _ in
+				XCTFail()
+		}
+		waitForExpectations(timeout: expTimeout, handler: nil)
+	}
+	
 	//MARK: All Tests
 	
 	


### PR DESCRIPTION
I found a pattern that the `any` operator does not work.

Please see below.

##### The pattern in which the `any` operator works.

```swift
let promise1 = Promise(resolved: "aaaa")
let promise2 = Promise(resolved: "bbbb")
any(promise1, promise2).then { str in
	print(str) //aaaa
}
```


##### The pattern in which the `any` operator does not works.

```swift
let promise1 = Promise { resolve, reject in
	resolve("aaaa")
}
let promise2 = Promise { resolve, reject in
	resolve("bbbb")
}
any(promise1, promise2).then { str in
	print(str)
}
```

It is reproduced if all the arguments of the `any` function are Promise objects that need to execute a body closure.

Is my recognition correct?