### PR TITLE
Add concurrency option to `all` operator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,17 @@ all(promises).then { usersAvatars in
 }
 ```
 
+If you add promise execution concurrency restriction to `all` operator  to avoid many usage of resource, `concurrency` option is it.
+
+```swift
+let promises = usernameList.map { return getAvatar(username: $0) }
+all(promises, concurrency: 4).then { usersAvatars in
+	// results of usersAvatars is same as `all` without concurrency.
+}.catch { err in
+	// something bad has occurred
+}
+```
+
 <a name="any" />
 
 ### any

--- a/Sources/Hydra/Promise+All.swift
+++ b/Sources/Hydra/Promise+All.swift
@@ -38,15 +38,14 @@ import Foundation
 /// It rejects as soon as a promises reject for any reason; result reject with returned error.
 ///
 /// - Parameters:
-///   - context: handler queue to run the handler on
 ///   - promises: list of promises to resolve in parallel
 /// - Returns: resolved promise which contains all resolved values from input promises (value are reported in the same order of input promises)
 public func all<L>(_ promises: Promise<L>...) -> Promise<[L]> {
 	return all(promises)
 }
 
-public func all<L, S: Sequence>(_ promises: S) -> Promise<[L]> where S.Iterator.Element == Promise<L> {
-	guard Array(promises).count > 0 else {
+public func all<L, S: Sequence>(_ promises: S, concurrency: UInt = UInt.max) -> Promise<[L]> where S.Iterator.Element == Promise<L> {
+	guard Array(promises).count > 0, concurrency > 0 else {
 		// If number of passed promises is zero we want to return a resolved promises with an empty array as result
 		return Promise<[L]>(resolved: [])
 	}
@@ -57,6 +56,7 @@ public func all<L, S: Sequence>(_ promises: S) -> Promise<[L]> where S.Iterator.
 	// in the same order of the input promises.
 	let allPromise = Promise<[L]> { (resolve, reject) in
 		var countRemaining = Array(promises).count
+		var countRunningPromises: UInt = 0
 		let allPromiseContext = Context.custom(queue: DispatchQueue(label: "com.hydra.queue.all"))
 		
 		for currentPromise in promises {
@@ -70,12 +70,18 @@ public func all<L, S: Sequence>(_ promises: S) -> Promise<[L]> where S.Iterator.
 					// with an array of all values results of our input promises (in the same order)
 					let allResults = promises.map({ return $0.state.value! })
 					resolve(allResults)
+				} else {
+					let nextPromise = promises.first(where: { $0.state.isPending && !$0.bodyCalled })
+					nextPromise?.runBody()
 				}
 				// if currentPromise reject the entire chain is broken and we reject the group Promise itself
 			}, onReject: { err in
 				reject(err)
 			})
-			currentPromise.runBody()
+			if concurrency > countRunningPromises {
+				currentPromise.runBody()
+				countRunningPromises += 1
+			}
 		}
 	}
 	return allPromise

--- a/Tests/HydraTests/HydraTests.swift
+++ b/Tests/HydraTests/HydraTests.swift
@@ -376,7 +376,25 @@ class HydraTestThen: XCTestCase {
 		}
 		waitForExpectations(timeout: expTimeout, handler: nil)
 	}
-
+	
+	/// `all` operator with comcurrency argument test.
+	/// body executable timing will restricted by concurrency.
+	func test_all_with_concurrency() {
+		let exp = expectation(description: "test_all_with_concurrency")
+		var timebasedResults = [Int]()
+		let promise1 = intPromiseDelayWithCompletion(3, delay: 0.5, completion: { timebasedResults.append($0) })
+		let promise2 = intPromiseDelayWithCompletion(12, delay: 0, completion: { timebasedResults.append($0) })
+		all([promise1, promise2], concurrency: 1).then { results in
+			XCTAssertEqual(results[0], 3)
+			XCTAssertEqual(results[1], 12)
+			XCTAssertEqual(timebasedResults[0], promise1.result!)
+			XCTAssertEqual(timebasedResults[1], promise2.result!)
+			exp.fulfill()
+		}.catch { _ in
+			XCTFail()
+		}
+		waitForExpectations(timeout: expTimeout, handler: nil)
+	}
 	
 	/// This is another test with `all` operator.
 	/// This test it's okay if all-promise is rejected because one of the input promise rejects.
@@ -671,6 +689,15 @@ class HydraTestThen: XCTestCase {
 	func intPromiseDelay(_ value: Int = 10, delay: TimeInterval) -> Promise<Int> {
 		return Promise<Int> { resolve, _ in
 			DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + delay, execute: {
+				resolve(value)
+			})
+		}
+	}
+	
+	func intPromiseDelayWithCompletion(_ value: Int = 10, delay: TimeInterval, completion: ((Int) -> Void)? = nil) -> Promise<Int> {
+		return Promise<Int> { resolve, _ in
+			DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + delay, execute: {
+				completion?(value)
 				resolve(value)
 			})
 		}


### PR DESCRIPTION
Hi.

In my project promise use case, I use `all` operator with over hundred download promise tasks.
If all of the tasks execute at same time, tasks exhaust huge resources(cpu, network, memory).

So I added concurrency option to `all` operator, it will suppress resource usage with `all` operator behavior and parallel tasks execution benefit.

Regard.