### PR TITLE
Fixed never chainable if return rejected promise in `recover` operator closure.

### DIFF
--- a/Sources/Hydra/Promise+Recover.swift
+++ b/Sources/Hydra/Promise+Recover.swift
@@ -52,7 +52,7 @@ public extension Promise {
 				// Body could return a new valid Promise of the same type or
 				// throws and reject the attempt.
 				do {
-					try body(error).then(in: ctx, resolve)
+					try body(error).then(in: ctx, resolve).catch(in: ctx, reject)
 				} catch (let error) {
 					reject(error)
 				}

--- a/Tests/HydraTests/HydraTests.swift
+++ b/Tests/HydraTests/HydraTests.swift
@@ -242,6 +242,20 @@ class HydraTestThen: XCTestCase {
 		waitForExpectations(timeout: expTimeout, handler: nil)
 	}
 	
+	/// If return rejected promise in `recover` operator, chain to next as its error.
+	func test_recover_failure() {
+		let exp = expectation(description: "test_recover_failure")
+		
+		let errPromise = intFailedPromiseImmediate(TestErrors.anotherError)
+		errPromise.recover { (err) -> Promise<Int> in
+			return Promise<Int>(rejected: TestErrors.someError)
+		}.catch { (e) -> (Void) in
+			XCTAssertEqual(e as! TestErrors, TestErrors.someError)
+			exp.fulfill()
+		}
+		waitForExpectations(timeout: expTimeout, handler: nil)
+	}
+	
 	//MARK: Pass tests
 	
 	


### PR DESCRIPTION
If we return rejected promise by `body(error)`, recover operator returned promise will be never chainable.

I think this use case also should chainable even if not `throw` the error.