### PR TITLE
Added `running` to the state of Promise.

### DIFF
--- a/Sources/Hydra/Commons.swift
+++ b/Sources/Hydra/Commons.swift
@@ -55,10 +55,12 @@ public enum PromiseError: Error {
 /// This represent the state of a Promise
 ///
 /// - pending: pending state. Promise was not evaluated yet.
+/// - running: running state. Promise is executing.
 /// - fulfilled: final state. Promise was fulfilled with expected value instance.
 /// - rejected: final state. Promise was rejected with given error.
 internal enum State<Value> {
 	case pending
+	case running
 	case resolved(_: Value)
 	case rejected(_: Error)
 	
@@ -74,11 +76,28 @@ internal enum State<Value> {
 		return error
 	}
 	
+	/// Return `true` if the promise is in `running` state, `false` otherwise.
+	var isRunning: Bool {
+		guard case .running = self else { return false }
+		return true
+	}
+	
 	/// Return `true` if the promise is in `pending` state, `false` otherwise.
 	var isPending: Bool {
 		guard case .pending = self else { return false }
 		return true
 	}
+	
+	/// Return `true` if the promise is either `resolved` or `rejected`. `false` otherwise
+	var isSettled: Bool {
+		switch self {
+		case .rejected(_), .resolved(_):
+			return true
+		default:
+			return false
+		}
+	}
+	
 }
 
 

--- a/Sources/Hydra/Promise+All.swift
+++ b/Sources/Hydra/Promise+All.swift
@@ -71,7 +71,7 @@ public func all<L, S: Sequence>(_ promises: S, concurrency: UInt = UInt.max) -> 
 					let allResults = promises.map({ return $0.state.value! })
 					resolve(allResults)
 				} else {
-					let nextPromise = promises.first(where: { $0.state.isPending && !$0.bodyCalled })
+					let nextPromise = promises.first(where: { $0.state.isPending })
 					nextPromise?.runBody()
 				}
 				// if currentPromise reject the entire chain is broken and we reject the group Promise itself


### PR DESCRIPTION
This is a suggestion.

If you define `running` as an enumerator of `State`, I think the code will be clean.
But will this be off the specification of `Promises / A +`?

>Requirements
>2.1. Promise States
>A promise must be in one of three states: pending, fulfilled, or rejected.

What about Hydra's requirement?