### PR TITLE
fixed all documents about `context` parameter.

### DIFF
--- a/Sources/Hydra/Promise+Always.swift
+++ b/Sources/Hydra/Promise+Always.swift
@@ -38,7 +38,7 @@ public extension Promise {
 	/// Always run given body at the end of a promise chain regardless of the whether the chain resolves or rejects.
 	///
 	/// - Parameters:
-	///   - queue: queue in which the body is executed
+	///   - context: context in which the body is executed (if not specified `background` is used)
 	///   - body: body to execute
 	/// - Returns: promise
 	@discardableResult

--- a/Sources/Hydra/Promise+Await.swift
+++ b/Sources/Hydra/Promise+Await.swift
@@ -74,7 +74,7 @@ public func await<T>(in context: Context? = nil, _ promise: Promise<T>) throws -
 /// call `resolve` or `reject` in order to complete it.
 ///
 /// - Parameters:
-///   - context: context in which the body will be executed in
+///   - context: context in which the body is executed (if not specified `background` is used)
 ///   - body: closure to execute
 /// - Returns: the value of the promise
 /// - Throws: an exception if operation fails

--- a/Sources/Hydra/Promise+Defer.swift
+++ b/Sources/Hydra/Promise+Defer.swift
@@ -38,9 +38,9 @@ public extension Promise {
 	/// Delay the executon of a Promise chain by some number of seconds from current time
 	///
 	/// - Parameters:
+	///   - context: context in which the body is executed (if not specified `background` is used)
 	///   - seconds: delay time in seconds; execution time is `.now()+seconds`
-	///   - result: the Promise to resolve to after the delay
-	/// - Returns: Promise
+	/// - Returns: the Promise to resolve to after the delay
 	public func `defer`(in context: Context? = nil, _ seconds: TimeInterval) -> Promise<Value> {
 		let ctx = context ?? .background
 		return self.then(in: ctx, { value in

--- a/Sources/Hydra/Promise+Pass.swift
+++ b/Sources/Hydra/Promise+Pass.swift
@@ -39,7 +39,7 @@ public extension Promise {
 	/// This operation does not effect the result value of the promise but it's able to reject the chain.
 	///
 	/// - Parameters:
-	///   - queue: queue in which the body is executed
+	///   - context: context in which the body is executed (if not specified `background` is used)
 	///   - body: body to execute
 	/// - Returns: a promise
 	public func pass<A>(in context: Context? = nil, _ body: @escaping (Value) throws -> Promise<A>) -> Promise<Value> {
@@ -55,7 +55,7 @@ public extension Promise {
 	/// This operation does not effect the result value of the promise but it's able to reject the chain.
 	///
 	/// - Parameters:
-	///   - queue: queue in which the body is executed
+	///   - context: context in which the body is executed (if not specified `background` is used)
 	///   - body: body to execute
 	/// - Returns: a promise
 	public func pass(in context: Context? = nil, _ handler: @escaping (Value) throws -> Void) -> Promise<Value> {

--- a/Sources/Hydra/Promise+Recover.swift
+++ b/Sources/Hydra/Promise+Recover.swift
@@ -38,7 +38,7 @@ public extension Promise {
 	/// Allows you to recover a failed promise by returning another promise with the same output
 	///
 	/// - Parameters:
-	///   - context: context in which the body is executed
+	///   - context: context in which the body is executed (if not specified `background` is used)
 	///   - body: body to execute. It must return a new promise to evaluate (our recover promise)
 	/// - Returns: a promise
 	public func recover(in context: Context? = nil, _ body: @escaping (Error) throws -> Promise<Value>) -> Promise<Value> {

--- a/Sources/Hydra/Promise+Reduce.swift
+++ b/Sources/Hydra/Promise+Reduce.swift
@@ -11,7 +11,7 @@ import Foundation
 /// Reduce a sequence of items with a asynchronous operation (Promise) to a single value
 ///
 /// - Parameters:
-///   - context: queue in which the reduce operation is made
+///   - context: context in which the transform is executed (if not specified `main` is used)
 ///   - items: initial value to begin reducing
 ///   - initial: sequence to reduce
 ///   - transform: transform function that accepts a partial result and sequence item

--- a/Sources/Hydra/Promise+Then.swift
+++ b/Sources/Hydra/Promise+Then.swift
@@ -41,7 +41,7 @@ public extension Promise {
 	/// Executed body can also reject the chain if throws.
 	///
 	/// - Parameters:
-	///   - queue: context in which the queue is executed
+	///   - context: context in which the body is executed (if not specified `main` is used)
 	///   - body: block to execute
 	/// - Returns: a chainable promise
 	@discardableResult
@@ -69,7 +69,7 @@ public extension Promise {
 	/// Executed body can also reject the chain if throws.
 	///
 	/// - Parameters:
-	///   - queue: queue in which the context is executed (if not specified `.main` is used)
+	///   - context: context in which the body is executed (if not specified `main` is used)
 	///   - body: body to execute
 	/// - Returns: chainable promise
 	@discardableResult
@@ -110,7 +110,7 @@ public extension Promise {
 	/// Returned object is a promise which is able to dispatch both error or resolved value of the promise.
 	///
 	/// - Parameters:
-	///   - queue: queue in which the context is executed (if not specified `.main` is used)
+	///   - context: context in which the body is executed (if not specified `main` is used)
 	///   - body: code block to execute
 	/// - Returns: a chainable promise
 	@discardableResult

--- a/Sources/Hydra/Promise+Timeout.swift
+++ b/Sources/Hydra/Promise+Timeout.swift
@@ -37,7 +37,7 @@ public extension Promise {
 	/// Reject the receiving Promise if it does not resolve or reject after a given number of seconds
 	///
 	/// - Parameters:
-	///   - queue: queue in which the reject is made
+	///   - context: context in which the nextPromise will be executed (if not specified `background` is used)
 	///   - timeout: timeout expressed in seconds
 	///   - error: error to report, if nil `PromiseError.timeout` is used instead
 	/// - Returns: promise

--- a/Sources/Hydra/Promise+Validate.swift
+++ b/Sources/Hydra/Promise+Validate.swift
@@ -41,7 +41,7 @@ public extension Promise {
 	/// If validation returns `false` (or `throws`) promise is rejected and the error is propagated over.
 	///
 	/// - Parameters:
-	///   - queue: queue in which the validation is executed
+	///   - context: context in which the validate is executed (if not specified `background` is used)
 	///   - validate: validate block
 	/// - Returns: promise
 	public func validate(in context: Context? = nil, _ validate: @escaping ((Value) throws -> (Bool))) -> Promise<Value> {


### PR DESCRIPTION
Fixed these incorrect docs.
- Some documents describe about older `queue` parameter.
- Some documents about `context` are missing default context.