### PR TITLE
Fixed cancelled promise never chainable when chain to retry or recover method.

### DIFF
--- a/Sources/Hydra/Promise+Recover.swift
+++ b/Sources/Hydra/Promise+Recover.swift
@@ -56,6 +56,8 @@ public extension Promise {
 				} catch (let error) {
 					reject(error)
 				}
+			}).cancelled(in: ctx, { _ -> Void in
+				operation.cancel()
 			})
 		})
 	}


### PR DESCRIPTION
Add missing canceled promise handling to `recover` method.