### PR TITLE
Await does not work on iOS 11

### DIFF
--- a/Sources/Hydra/Promise+Await.swift
+++ b/Sources/Hydra/Promise+Await.swift
@@ -121,7 +121,7 @@ public extension Context {
 		}
 	
 		// Wait and block code execution until promise is fullfilled or rejected
-		_ = semaphore.wait(timeout: DispatchTime(uptimeNanoseconds: UInt64.max))
+		_ = semaphore.wait(timeout: .distantFuture)
 		
 		guard let promiseValue = result else {
 			throw error!


### PR DESCRIPTION
Replace ``DispatchTime(uptimeNanoseconds: UInt64.mx)`` with ``DispatchTime.distantFuture`` to fix the crash