### PR TITLE
Replace '(Void)' with '()'

### DIFF
--- a/Sources/Hydra/Commons.swift
+++ b/Sources/Hydra/Commons.swift
@@ -95,7 +95,7 @@ public struct PromiseStatus {
 	internal var token: InvalidationToken?
 	
 	/// Cancel Promise workflow and mark the promise itself as `cancelled`.
-	public let cancel: ((Void) -> (Void))
+	public let cancel: (() -> ())
 	
 	/// Check if the promise is valid by querying your provided `InvalidatableProtocol` object.
 	public var isCancelled: Bool {
@@ -104,7 +104,7 @@ public struct PromiseStatus {
 	
 	// Initialize a new `PromiseStatus` object.
 	// You don't need to do it manually, it's done when a new `Promise` is initialized with a valida `InvalidatableProtocol`
-	internal init(token: InvalidationToken? = nil, _ action: @escaping ((Void) -> (Void))) {
+	internal init(token: InvalidationToken? = nil, _ action: @escaping (() -> ())) {
 		self.token = token
 		self.cancel = action
 	}

--- a/Sources/Hydra/Promise+Async.swift
+++ b/Sources/Hydra/Promise+Async.swift
@@ -56,7 +56,7 @@ public func async<T>(in context: Context? = nil, _ body: @escaping ( () throws -
 ///   - context: context in which the block will be executed
 ///	  - after: allows you to specify a delay interval before executing the block itself.
 ///   - block: block to execute
-public func async(in context: Context, after: TimeInterval? = nil, _ block: @escaping () -> (Void)) -> Void {
+public func async(in context: Context, after: TimeInterval? = nil, _ block: @escaping () -> ()) -> Void {
 	guard let delay = after else {
 		context.queue.async {
 			block()

--- a/Sources/Hydra/Promise+Cancel.swift
+++ b/Sources/Hydra/Promise+Cancel.swift
@@ -41,7 +41,7 @@ public extension Promise {
 	///   - body: body to execute
 	/// - Returns: a new void promise
 	@discardableResult
-	public func cancelled(in context: Context? = nil, _ body: @escaping ((Void) -> ((Void)))) -> Promise<Void> {
+	public func cancelled(in context: Context? = nil, _ body: @escaping (() -> (()))) -> Promise<Void> {
 		let ctx = context ?? .main
 		let nextPromise = Promise<Void>(in: ctx, token: self.invalidationToken) { resolve, reject, operation in
 			let onResolve = Observer.onResolve(ctx, { _ in

--- a/Sources/Hydra/Promise+Catch.swift
+++ b/Sources/Hydra/Promise+Catch.swift
@@ -42,7 +42,7 @@ public extension Promise {
 	///   - body: body to execute
 	/// - Returns: a promise
 	@discardableResult
-	public func `catch`(in context: Context? = nil, _ body: @escaping ((Error) throws -> (Void))) -> Promise<Void> {
+	public func `catch`(in context: Context? = nil, _ body: @escaping ((Error) throws -> ())) -> Promise<Void> {
 		let ctx = context ?? .main
 		let nextPromise = Promise<Void>(in: ctx, token: self.invalidationToken) { resolve, reject, operation in
 			let onResolve = Observer.onResolve(ctx, { _ in

--- a/Sources/Hydra/Promise+Map.swift
+++ b/Sources/Hydra/Promise+Map.swift
@@ -90,7 +90,7 @@ public func map_series<A, B, S: Sequence>(context: Context, items: S, transform:
 internal func map_parallel<A, B, S: Sequence>(context: Context, items: S, transform: @escaping (A) throws -> Promise<B>) -> Promise<[B]> where S.Iterator.Element == A {
 	
 	let transformPromise = Promise<Void>(resolved: ())
-	return transformPromise.then(in: context) { (Void) -> Promise<[B]> in
+	return transformPromise.then(in: context) { () -> Promise<[B]> in
 		do {
 			let mappedPromises: [Promise<B>] = try items.map({ item in
 				return try transform(item)

--- a/Sources/Hydra/Promise+Observer.swift
+++ b/Sources/Hydra/Promise+Observer.swift
@@ -42,8 +42,8 @@ extension Promise {
 	/// - onResolve: register an handler which is executed only if target promise is fulfilled.
 	/// - onReject: register an handler which is executed only if target promise is rejected.
 	public indirect enum Observer {
-		public typealias ResolveObserver = ((Value) -> (Void))
-		public typealias RejectObserver = ((Error) -> (Void))
+		public typealias ResolveObserver = ((Value) -> ())
+		public typealias RejectObserver = ((Error) -> ())
 		public typealias CancelObserver = (() -> ())
 		
 		case onResolve(_: Context, _: ResolveObserver)

--- a/Sources/Hydra/Promise+Recover.swift
+++ b/Sources/Hydra/Promise+Recover.swift
@@ -56,7 +56,7 @@ public extension Promise {
 				} catch (let error) {
 					reject(error)
 				}
-			}).cancelled(in: ctx, { _ -> Void in
+			}).cancelled(in: ctx, { () -> Void in
 				operation.cancel()
 			})
 		})

--- a/Tests/HydraTests/HydraTests.swift
+++ b/Tests/HydraTests/HydraTests.swift
@@ -249,7 +249,7 @@ class HydraTestThen: XCTestCase {
 		let errPromise = intFailedPromiseImmediate(TestErrors.anotherError)
 		errPromise.recover { (err) -> Promise<Int> in
 			return Promise<Int>(rejected: TestErrors.someError)
-			}.catch { (e) -> (Void) in
+			}.catch { (e) -> () in
 				XCTAssertEqual(e as! TestErrors, TestErrors.someError)
 				exp.fulfill()
 		}
@@ -765,7 +765,7 @@ class HydraTestThen: XCTestCase {
 				XCTFail()
 				return value == 2
 			}
-			.catch { (error) -> (Void) in
+			.catch { (error) -> () in
 				XCTFail()
 			}.cancelled {
 				print("Operation cancelled")


### PR DESCRIPTION
This PR fixes the following warnings occurs on Xcode 9.

<img width="480" alt="warning_on_xcode9" src="https://user-images.githubusercontent.com/2959791/29957074-7b973046-8f26-11e7-87e4-8691ad36f4e9.png">
