### PR TITLE
Hydra does not compiles with SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,14 @@
+// swift-tools-version:4.0
 import PackageDescription
 
 let package = Package(
-    name: "Hydra"
+    name: "Hydra",
+    products: [
+        .library(name: "Hydra", targets: ["Hydra"])
+    ],
+    targets: [
+        .target(name: "Hydra", dependencies: []),
+        .testTarget(name: "HydraTests", dependencies: ["Hydra"])
+    ],
+    swiftLanguageVersions: [4]
 )


### PR DESCRIPTION
SPM compiles Hydra in Swift 3 mode because package description uses old API, but Hydra uses method ``schedule(deadline:repeating:leeway:)`` that only available in Swift 4.